### PR TITLE
Fix and support terminate() and close()

### DIFF
--- a/lib/__tests__/baseworker.spec.js
+++ b/lib/__tests__/baseworker.spec.js
@@ -1,13 +1,48 @@
 import BaseWorker from '../baseworker';
 
+function processMessage(e, close) {
+  if (!e.data) throw Error();
+  if (e.data == 'close and error') {
+    close();
+    throw Error();
+  }
+  if (e.data == -1) close();
+  return e.data*2;
+}
 
-class TestWorker extends BaseWorker {
-  main(self, addEventListener, removeEventListener, dispatchEvent, postMessage, terminate) {
+class TestWorker1 extends BaseWorker {
+  main(self, addEventListener, removeEventListener, dispatchEvent, postMessage, close) {
     const onmessage = e => {
-      if (!e.data) throw Error();
-      postMessage(e.data*2);
+      postMessage(processMessage(e, close));
     };
     return onmessage;
+  }
+}
+
+class TestWorker2 extends BaseWorker {
+  main(self, addEventListener, removeEventListener, dispatchEvent, postMessage, close) {
+    addEventListener('message', e => {
+      dispatchEvent('message', { data: processMessage(e, close) });
+    });
+  }
+}
+
+class TestWorker3 extends BaseWorker {
+  main(self, addEventListener, removeEventListener, dispatchEvent, postMessage, close) {
+    let onmessage = e => {
+      throw new Error('should never be called!');
+    };
+    let onmessage2 = e => {
+      postMessage(processMessage(e, close));
+    };
+    let onmessage3 = e => {
+      throw new Error('should never be called!');
+    };
+    addEventListener('message', onmessage);
+    addEventListener('message', onmessage2);
+    addEventListener('message', onmessage3);
+    removeEventListener('message', onmessage);
+    removeEventListener('message', onmessage3);
   }
 }
 
@@ -15,13 +50,21 @@ const sleep = t => new Promise( r => { setTimeout(r, t); });
 
 
 describe('BaseWorker class', () => {
-  describe('execution', () => {
+  const defineTests = (TestWorker) => () => {
     it('instantiate a BaseWorker', async() => {
       const worker = new TestWorker();
       worker.onmessage = jest.fn();
       worker.postMessage(5);
       await sleep(10);
       expect(worker.onmessage).toHaveBeenCalledWith({ data: 10 });
+    });
+    it('instantiate a BaseWorker using event listeners and dispatch', async() => {
+      const worker = new TestWorker();
+      const onmessage = jest.fn();
+      worker.addEventListener('message', onmessage);
+      worker.dispatchEvent('message', { data: 5 });
+      await sleep(10);
+      expect(onmessage).toHaveBeenCalledWith({ data: 10 });
     });
     it('handles errors correctly', async () => {
       const worker = new TestWorker();
@@ -30,8 +73,79 @@ describe('BaseWorker class', () => {
       await sleep(10);
       expect(worker.onerror).toHaveBeenCalled();
     });
-    it('terminate a worker', async() => {
+    it('handles errors correctly using event listeners and dispatch', async () => {
       const worker = new TestWorker();
+      const onerror = jest.fn();
+      worker.addEventListener('error', onerror);
+      worker.dispatchEvent('message', {});
+      await sleep(10);
+      expect(onerror).toHaveBeenCalled();
     });
-  });
+    it('terminates a worker', async() => {
+      const worker = new TestWorker();
+      worker.onmessage = jest.fn();
+      worker.onerror = jest.fn();
+      worker.terminate();
+      worker.postMessage(5);
+      worker.postMessage(undefined);
+      await sleep(10);
+      expect(worker.onmessage).not.toHaveBeenCalled();
+      expect(worker.onerror).not.toHaveBeenCalled();
+    });
+    it('closes a worker', async() => {
+      const worker = new TestWorker();
+      worker.onmessage = jest.fn();
+      worker.onerror = jest.fn();
+      worker.postMessage(-1);
+      worker.postMessage(5);
+      worker.postMessage(undefined);
+      worker.postMessage('close and error');
+      await sleep(10);
+      expect(worker.onmessage).not.toHaveBeenCalled();
+      expect(worker.onerror).not.toHaveBeenCalled();
+    });
+    it('closes a worker and throws error', async() => {
+      const worker = new TestWorker();
+      worker.onmessage = jest.fn();
+      worker.onerror = jest.fn();
+      worker.postMessage('close and error');
+      worker.postMessage(5);
+      worker.postMessage(undefined);
+      worker.postMessage(-1);
+      await sleep(10);
+      expect(worker.onmessage).not.toHaveBeenCalled();
+      expect(worker.onerror).not.toHaveBeenCalled();
+    });
+    it('closes a worker using event listeners and dispatch', async() => {
+      const worker = new TestWorker();
+      const onmessage = jest.fn();
+      const onerror = jest.fn();
+      worker.addEventListener('message', onmessage);
+      worker.addEventListener('error', onerror);
+      worker.dispatchEvent('message', { data: -1 });
+      worker.dispatchEvent('message', { data: 5 });
+      worker.dispatchEvent('message', {});
+      worker.dispatchEvent('message', { data: 'close and error' });
+      await sleep(10);
+      expect(onmessage).not.toHaveBeenCalled();
+      expect(onerror).not.toHaveBeenCalled();
+    });
+    it('closes a worker and throws error using event listeners and dispatch', async() => {
+      const worker = new TestWorker();
+      const onmessage = jest.fn();
+      const onerror = jest.fn();
+      worker.addEventListener('message', onmessage);
+      worker.addEventListener('error', onerror);
+      worker.dispatchEvent('message', { data: 'close and error' });
+      worker.dispatchEvent('message', { data: 5 });
+      worker.dispatchEvent('message', {});
+      worker.dispatchEvent('message', { data: -1 });
+      await sleep(10);
+      expect(onmessage).not.toHaveBeenCalled();
+      expect(onerror).not.toHaveBeenCalled();
+    });
+  };
+  describe('execution with TestWorker1', defineTests(TestWorker1));
+  describe('execution with TestWorker2', defineTests(TestWorker2));
+  describe('execution with TestWorker3', defineTests(TestWorker3));
 });

--- a/lib/baseworker.js
+++ b/lib/baseworker.js
@@ -1,48 +1,88 @@
 const mitt = require('mitt');
 
+function addWrappedEventListener(target, listeners, name, listener, wrappedListener) {
+  listeners[name] = [...(listeners[name] || []), [listener, wrappedListener]];
+  target.on(name, wrappedListener);
+}
+
+function removeWrappedEventListener(target, listeners, name, listener) {
+  let wrappedListeners = listeners[name];
+  for (let [i, [l, wrappedListener]] of wrappedListeners.entries()) {
+    if (l === listener) {
+      wrappedListeners.slice(i, 1);
+      target.off(name, wrappedListener);
+      break;
+    }
+  }
+}
+
 class BaseWorker {
   constructor () {
     let inside = mitt();
+    let insideListeners = [];
     let outside = mitt();
+    let closed = false;
 
     let self = {};
 
-    self.addEventListener = outside.on;
-    self.removeEventListener = outside.off;
-    self.dispatchEvent = outside.emit;
-    self.postMessage = data => {
-      inside.emit('message', { data });
+    // Inside
+    self.addEventListener = (name, listener) => {
+      addWrappedEventListener(inside, insideListeners, name, listener, event => {
+        try {
+          listener(event);
+        }
+        catch (error) {
+          if (!closed) outside.emit('error', { error });
+        }
+      });
     };
-    self.terminate = () => {
-      console.log('Warning: this method is not supported yet');
+    self.removeEventListener = (name, listener) => {
+      removeWrappedEventListener(inside, insideListeners, name, listener);
+    };
+    self.dispatchEvent = (e, m) => {
+      if (!closed) outside.emit(e, m);
+    };
+    self.postMessage = data => {
+      self.dispatchEvent('message', { data });
+    };
+    self.close = () => {
+      closed = true;
     };
 
+    // Outside
     this.onmessage = null;
     this.onerror = null;
-    this.dispatchEvent = inside.emit;
-    this.addEventListener = inside.on;
-    this.removeEventListener = inside.off;
+    this.dispatchEvent = (e, m) => {
+      if (!closed) inside.emit(e, m);
+    };
+    this.addEventListener = outside.on;
+    this.removeEventListener = outside.off;
     this.postMessage = (data) => {
-      outside.emit('message', { data });
+      this.dispatchEvent('message', { data });
+    };
+    this.terminate = () => {
+      closed = true;
     };
 
-    inside.on('message', e => {
+    outside.on('message', e => {
       if (this.onmessage) this.onmessage(e);
     });
-    inside.on('error', e => {
+    outside.on('error', e => {
       if (this.onerror) this.onerror(e);
     });
 
-    let onmessage = this.main(self, self.addEventListener, self.removeEventListener, self.dispatchEvent, self.postMessage, self.terminate);
+    let onmessage = this.main(self, self.addEventListener, self.removeEventListener, self.dispatchEvent, self.postMessage, self.close);
 
-    outside.on('message', e => {
-      try {
-        if (onmessage) onmessage(e);
-      }
-      catch (error) {
-        inside.emit('error', { error });
-      }
-    });
+    if (onmessage) {
+      inside.on('message', e => {
+        try {
+          onmessage(e);
+        }
+        catch (error) {
+          if (!closed) outside.emit('error', { error });
+        }
+      });
+    }
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "workerloader-jest-transformer",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.0.4",
+      "name": "workerloader-jest-transformer",
+      "version": "0.0.5",
       "license": "MIT",
       "dependencies": {
         "mitt": "^2.1.0"

--- a/templates/worker.js
+++ b/templates/worker.js
@@ -3,7 +3,7 @@ import BaseWorker from 'workerloader-jest-transformer/lib/baseworker'
 
 export default class WebWorker extends BaseWorker {
 
-  main(self, addEventListener, removeEventListener, dispatchEvent, postMessage, terminate) {
+  main(self, addEventListener, removeEventListener, dispatchEvent, postMessage, close) {
     /* {% WORKER_CODE %} */
     return typeof onmessage !== 'undefined' ? onmessage : self.onmessage
   }

--- a/utils/__tests__/code/myworker_noimport.js
+++ b/utils/__tests__/code/myworker_noimport.js
@@ -1,0 +1,1 @@
+workerHandler('data')

--- a/utils/__tests__/code/wrapped_result.js
+++ b/utils/__tests__/code/wrapped_result.js
@@ -3,7 +3,7 @@ import workerHandler from './handlers'
 
 export default class WebWorker extends BaseWorker {
 
-  main(self, addEventListener, removeEventListener, dispatchEvent, postMessage, terminate) {
+  main(self, addEventListener, removeEventListener, dispatchEvent, postMessage, close) {
     
     
     workerHandler('data')

--- a/utils/__tests__/code/wrapped_result.ts
+++ b/utils/__tests__/code/wrapped_result.ts
@@ -1,10 +1,13 @@
 import BaseWorker from 'workerloader-jest-transformer/lib/baseworker'
-/* {% WORKER_IMPORTS %} */
+import workerHandler from './handlers'
 
 export default class WebWorker extends BaseWorker {
 
   main(self: any, addEventListener: any, removeEventListener: any, dispatchEvent: any, postMessage: any, close: any) {
-    /* {% WORKER_CODE %} */
+    
+    
+    workerHandler('data')
+    
     return typeof onmessage !== 'undefined' ? onmessage : self.onmessage
   }
 

--- a/utils/__tests__/stripper.spec.js
+++ b/utils/__tests__/stripper.spec.js
@@ -14,5 +14,14 @@ describe('Stripper module', () => {
       expect(strippedResult.code).toContain('workerHandler(\'data\')');
       expect(strippedResult.imports[0]).toBe('import workerHandler from \'./handlers\'');
     });
+    it('should handle no imports correctly', () => {
+      const src = fs.readFileSync(
+        path.resolve(__dirname, 'code', 'myworker_noimport.js'),
+        {encoding:'utf8', flag:'r'}
+      );
+      const strippedResult = stripImports(src)
+      expect(strippedResult.code).toContain('workerHandler(\'data\')');
+      expect(strippedResult.imports.length).toBe(0);
+    });
   });
 });

--- a/utils/__tests__/wrapper.spec.js
+++ b/utils/__tests__/wrapper.spec.js
@@ -5,17 +5,19 @@ import { wrapSource } from '../wrapper';
 
 describe('Wrapper module', () => {
   describe('wrapSource', () => {
-    it('should wrap custom worker code inside a Worker class', () => {
-      const src = fs.readFileSync(
-        path.resolve(__dirname, 'code', 'myworker.js'),
-        {encoding:'utf8', flag:'r'}
-      );
-      const desiredWrappedSrc = fs.readFileSync(
-        path.resolve(__dirname, 'code', 'wrapped_result.js'),
-        {encoding:'utf8', flag:'r'}
-      );
-      const wrappedSrc = wrapSource(src)
-      expect(wrappedSrc).toEqual(desiredWrappedSrc)
-    });
+    for (const lang of ['js', 'ts']) {
+      it('should wrap custom ' + lang + ' worker code inside a Worker class', () => {
+        const src = fs.readFileSync(
+          path.resolve(__dirname, 'code', 'myworker.js'),
+          {encoding:'utf8', flag:'r'}
+        );
+        const desiredWrappedSrc = fs.readFileSync(
+          path.resolve(__dirname, 'code', 'wrapped_result.' + lang),
+          {encoding:'utf8', flag:'r'}
+        );
+        const wrappedSrc = wrapSource(src, lang == 'js' ? undefined : lang)
+        expect(wrappedSrc).toEqual(desiredWrappedSrc)
+      });
+    }
   });
 });


### PR DESCRIPTION
- move terminate() outside and add close() inside to comply with spec
- emulate terminate() and close() semantics by making them cause further messages to be dropped
- refactor to unconfuse inside vs outside in general
- improve test coverage